### PR TITLE
Added main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
   },
   "scripts": {
     "test": "mocha"
-  }
+  },
+  "main":"Args.js"
 }


### PR DESCRIPTION
Currently the way to require this module in node is by 

```
Args = require("args-js/Args.js") 
```

which is a bit ugly. Setting the main allows you to do a nice require of 

```
Args = require("args-js")
```
